### PR TITLE
feat: Add progress output option

### DIFF
--- a/DiscordChatExporter.Cli/Commands/Base/TokenCommandBase.cs
+++ b/DiscordChatExporter.Cli/Commands/Base/TokenCommandBase.cs
@@ -27,8 +27,16 @@ public abstract class TokenCommandBase : ICommand
     )]
     public bool IsBotToken { get; init; }
 
+    [CommandOption(
+        "progress",
+        EnvironmentVariable = "PROGRESS_OUTPUT_PATH",
+        Description = "Progress file path."
+    )]
+    public string? ProgressPath { get; init; }
+
+
     private DiscordClient? _discordClient;
-    protected DiscordClient Discord => _discordClient ??= new DiscordClient(Token);
+    protected DiscordClient Discord => _discordClient ??= new DiscordClient(Token, ProgressPath);
 
     public abstract ValueTask ExecuteAsync(IConsole console);
 }

--- a/DiscordChatExporter.Core/Utils/Extensions/LoggingExtensions.cs
+++ b/DiscordChatExporter.Core/Utils/Extensions/LoggingExtensions.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DiscordChatExporter.Core.Utils.Extensions;
+
+public static class LoggingExtensions
+{
+    static ReaderWriterLockSlim locker = new ReaderWriterLockSlim();
+
+    public static void WriteDebug(this string text, string path)
+    {
+        try
+        {
+            locker.EnterWriteLock();
+            System.IO.File.AppendAllLines(path, new[] { text });
+        }
+        finally
+        {
+            locker.ExitWriteLock();
+        }
+    }
+}


### PR DESCRIPTION
I have added support of outputting progress info to a file. To enable this you may:

1. Add argument `--progress <progress_file_path>`, OR,
2. Set environment variable `PROGRESS_OUTPUT_PATH ` to your desired path

The current output format is like:

```
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1020/10000"
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1021/10000"
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1021/10000"
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1021/10000"
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1022/10000"
[2022-08-17 02:44:57 +08] channel_id=915930516220444672, progress="1022/10000"
[2022-08-17 02:44:58 +08] channel_id=915930516220444672, progress="1022/10000"
[2022-08-17 02:44:58 +08] channel_id=915930516220444672, progress="1023/10000"
[2022-08-17 02:44:58 +08] channel_id=915930516220444672, progress="1023/10000"
[2022-08-17 02:44:58 +08] channel_id=915930516220444672, progress="1024/10000"
```

Log writing is implemented thread-safe, but the multithread case is not locally tested (because we don't use this function). Single-thread case is tested and works properly.

