### PR TITLE
fix: referencedMessage JSON formet

### DIFF
--- a/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
+++ b/DiscordChatExporter.Core/Exporting/Writers/JsonMessageWriter.cs
@@ -364,9 +364,8 @@ internal class JsonMessageWriter : MessageWriter
         // Referenced message
         if (message.ReferencedMessage is not null)
         {
-            _writer.WriteStartObject("referencedMessage");
+            _writer.WritePropertyName("referencedMessage");
             await WriteMessageAsync(message.ReferencedMessage, cancellationToken);
-            _writer.WriteEndObject();
         }
 
         _writer.WriteEndObject();


### PR DESCRIPTION
Currently referencedMessage have a wrong format and is causing errors on ECS. Is has been fixed by this PR.

Please merge this fix ASAP. Thanks. 